### PR TITLE
Implement password reset functionality with email notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,7 @@ PORT=8000
 
 # CORS Settings (comma-separated)
 CORS_ORIGINS=*
+FRONTEND_URL=http://localhost:5173
 
 # PostgreSQL Database
 POSTGRES_HOST=localhost
@@ -27,6 +28,13 @@ DATABASE_MAX_OVERFLOW=20
 SECRET_KEY=your-secret-key-change-this-in-production-use-openssl-rand-hex-32
 ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=30
+REFRESH_TOKEN_EXPIRE_DAYS=30
+
+# AWS SES Configuration
+AWS_REGION=us-east-1
+AWS_ACCESS_KEY_ID=your-aws-access-key-id
+AWS_SECRET_ACCESS_KEY=your-aws-secret-access-key
+SES_FROM_EMAIL=noreply@example.com
 
 # Sentry (Optional - leave empty to disable)
 SENTRY_DSN=
@@ -41,3 +49,4 @@ RABBITMQ_PASS=guest
 
 # Flower (Celery Monitoring)
 FLOWER_BASIC_AUTH=admin:admin123
+

--- a/app/celery_app.py
+++ b/app/celery_app.py
@@ -55,6 +55,7 @@ app.autodiscover_tasks(['app.tasks'])
 
 try:
     from app.tasks import draw
+    from app.tasks import email_tasks
 except ImportError as e:
     pass
 

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -28,6 +28,7 @@ class Settings(BaseSettings):
     
     # CORS Settings
     cors_origins: List[str] = ["*"]
+    frontend_url: str = "http://localhost:5173"
     
     # PostgreSQL Connection Details
     postgres_host: str = "localhost"

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -6,12 +6,16 @@ from app.schemas.user import (
     UserCreate,
     UserLogin,
     TokenResponse,
-    RefreshTokenRequest
+    RefreshTokenRequest,
+    ForgotPasswordRequest,
+    ResetPasswordRequest
 )
 
 __all__ = [
     "UserCreate",
     "UserLogin",
     "TokenResponse",
-    "RefreshTokenRequest"
+    "RefreshTokenRequest",
+    "ForgotPasswordRequest",
+    "ResetPasswordRequest"
 ]

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -39,3 +39,15 @@ class TokenResponse(BaseModel):
 class RefreshTokenRequest(BaseModel):
     """Schema for refresh token request"""
     refresh_token: str
+
+
+class ForgotPasswordRequest(BaseModel):
+    """Schema for forgot password request"""
+    email: EmailStr
+    language: str = "tr"
+
+
+class ResetPasswordRequest(BaseModel):
+    """Schema for reset password request"""
+    token: str
+    new_password: str

--- a/app/tasks/email_tasks.py
+++ b/app/tasks/email_tasks.py
@@ -1,0 +1,47 @@
+"""
+Celery Tasks for Email Operations
+"""
+
+import logging
+from typing import Dict, Any
+from app.celery_app import app
+from app.services.email_service import EmailService
+from app.models.draw import Language
+
+logger = logging.getLogger(__name__)
+
+
+@app.task(bind=True, name='send_password_reset_email_task')
+def send_password_reset_email_task(
+    self,
+    email: str,
+    token: str,
+    language: str = Language.TR.value
+) -> Dict[str, Any]:
+    """
+    Send password reset email asynchronously
+    
+    Args:
+        email: User's email address
+        token: Reset token
+        language: Language code (default: tr)
+        
+    Returns:
+        Dict with status and message
+    """
+    logger.info(f"Starting send_password_reset_email_task for {email}")
+    
+    try:
+        email_service = EmailService()
+        success = email_service.send_password_reset_email(email, token, language)
+        
+        if success:
+            logger.info(f"Password reset email sent successfully to {email}")
+            return {"status": "success", "message": f"Email sent to {email}"}
+        else:
+            logger.error(f"Failed to send password reset email to {email}")
+            return {"status": "error", "message": f"Failed to send email to {email}"}
+            
+    except Exception as e:
+        logger.error(f"Unexpected error in send_password_reset_email_task: {e}", exc_info=True)
+        return {"status": "error", "message": str(e)}

--- a/app/templates/reset-password-template-en.html
+++ b/app/templates/reset-password-template-en.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Password Reset</title>
+    <link href="https://fonts.googleapis.com/css2?family=Great+Vibes&display=swap" rel="stylesheet">
+    <style>
+        body,
+        p,
+        h1,
+        h2,
+        td {
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+            background-color: #DC2626;
+        }
+
+        table {
+            border-collapse: collapse;
+        }
+
+        a {
+            text-decoration: none;
+        }
+    </style>
+</head>
+
+<body style="margin: 0; padding: 0; background-color: #DC2626;">
+    <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0">
+        <tr>
+            <td align="center" style="padding: 20px 10px;">
+                <!-- Main Container -->
+                <table role="presentation" width="100%"
+                    style="max-width: 600px; background-color: #ffffff; border-radius: 24px; overflow: hidden; box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);">
+
+                    <!-- Header Section -->
+                    <tr>
+                        <td align="center"
+                            style="background-color: #FEF2F2; padding: 40px 20px 30px 20px; border-bottom: 4px solid #FEE2E2;">
+                            <!-- Branding -->
+                            <p
+                                style="font-size: 12px; font-weight: 700; color: #DC2626; text-transform: uppercase; letter-spacing: 2px; margin-bottom: 20px; opacity: 0.8;">
+                                Letsraffle.co
+                            </p>
+
+                            <h1
+                                style="color: #DC2626; margin-top: 20px; font-family: 'Great Vibes', 'Brush Script MT', cursive; font-size: 42px; font-weight: 400; letter-spacing: 1px;">
+                                Password Reset</h1>
+                        </td>
+                    </tr>
+
+                    <!-- Content Section -->
+                    <tr>
+                        <td style="padding: 40px 30px;">
+                            <p style="font-size: 18px; color: #374151; margin-bottom: 20px; text-align: center;">
+                                Hello,
+                            </p>
+                            <p
+                                style="font-size: 16px; color: #4B5563; line-height: 1.6; margin-bottom: 30px; text-align: center;">
+                                We received a request to reset your password. Click the button below to reset it.
+                            </p>
+
+                            <!-- Action Button -->
+                            <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0"
+                                style="margin-bottom: 30px;">
+                                <tr>
+                                    <td align="center">
+                                        <a href="{{reset_link}}"
+                                            style="display: inline-block; background-color: #DC2626; color: #ffffff; padding: 14px 30px; border-radius: 8px; font-size: 16px; font-weight: 600; text-decoration: none; box-shadow: 0 4px 6px -1px rgba(220, 38, 38, 0.2); transition: background-color 0.2s;">
+                                            Reset Password
+                                        </a>
+                                    </td>
+                                </tr>
+                            </table>
+
+                            <p style="font-size: 14px; color: #6B7280; line-height: 1.6; text-align: center;">
+                                If you didn't request this, you can safely ignore this email.
+                            </p>
+                        </td>
+                    </tr>
+
+                    <!-- Footer Section -->
+                    <tr>
+                        <td
+                            style="background-color: #F9FAFB; padding: 40px 30px; text-align: center; border-top: 1px solid #E5E7EB;">
+
+                            <p style="font-size: 13px; color: #9CA3AF; margin: 0;">
+                                Contact: <a href="mailto:hey@letsraffle.co"
+                                    style="color: #6B7280; text-decoration: underline;">hey@letsraffle.co</a>
+                            </p>
+                        </td>
+                    </tr>
+                </table>
+
+                <!-- Copyright -->
+                <p style="text-align: center; margin-top: 20px; font-size: 12px; color: #FECACA; opacity: 0.8;">
+                    © 2025 LetsRaffle. All rights reserved.
+                </p>
+            </td>
+        </tr>
+    </table>
+</body>
+
+</html>

--- a/app/templates/reset-password-template-tr.html
+++ b/app/templates/reset-password-template-tr.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="tr">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Şifre Sıfırlama</title>
+    <link href="https://fonts.googleapis.com/css2?family=Great+Vibes&display=swap" rel="stylesheet">
+    <style>
+        /* Reset styles */
+        body,
+        p,
+        h1,
+        h2,
+        td {
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+            background-color: #DC2626;
+        }
+
+        table {
+            border-collapse: collapse;
+        }
+
+        a {
+            text-decoration: none;
+        }
+    </style>
+</head>
+
+<body style="margin: 0; padding: 0; background-color: #DC2626;">
+    <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0">
+        <tr>
+            <td align="center" style="padding: 20px 10px;">
+                <!-- Main Container -->
+                <table role="presentation" width="100%"
+                    style="max-width: 600px; background-color: #ffffff; border-radius: 24px; overflow: hidden; box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);">
+
+                    <!-- Header Section -->
+                    <tr>
+                        <td align="center"
+                            style="background-color: #FEF2F2; padding: 40px 20px 30px 20px; border-bottom: 4px solid #FEE2E2;">
+                            <!-- Branding -->
+                            <p
+                                style="font-size: 12px; font-weight: 700; color: #DC2626; text-transform: uppercase; letter-spacing: 2px; margin-bottom: 20px; opacity: 0.8;">
+                                Letsraffle.co
+                            </p>
+
+                            <h1
+                                style="color: #DC2626; margin-top: 20px; font-family: 'Great Vibes', 'Brush Script MT', cursive; font-size: 42px; font-weight: 400; letter-spacing: 1px;">
+                                Şifre Sıfırlama</h1>
+                        </td>
+                    </tr>
+
+                    <!-- Content Section -->
+                    <tr>
+                        <td style="padding: 40px 30px;">
+                            <p style="font-size: 18px; color: #374151; margin-bottom: 20px; text-align: center;">
+                                Merhaba,
+                            </p>
+                            <p
+                                style="font-size: 16px; color: #4B5563; line-height: 1.6; margin-bottom: 30px; text-align: center;">
+                                Şifrenizi sıfırlamak için bir talep aldık. Aşağıdaki butona tıklayarak şifrenizi yenileyebilirsiniz.
+                            </p>
+
+                            <!-- Action Button -->
+                            <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0" style="margin-bottom: 30px;">
+                                <tr>
+                                    <td align="center">
+                                        <a href="{{reset_link}}"
+                                            style="display: inline-block; background-color: #DC2626; color: #ffffff; padding: 14px 30px; border-radius: 8px; font-size: 16px; font-weight: 600; text-decoration: none; box-shadow: 0 4px 6px -1px rgba(220, 38, 38, 0.2); transition: background-color 0.2s;">
+                                            Şifremi Sıfırla
+                                        </a>
+                                    </td>
+                                </tr>
+                            </table>
+
+                            <p style="font-size: 14px; color: #6B7280; line-height: 1.6; text-align: center;">
+                                Eğer bu talebi siz yapmadıysanız, bu e-postayı görmezden gelebilirsiniz.
+                            </p>
+                        </td>
+                    </tr>
+
+                    <!-- Footer Section -->
+                    <tr>
+                        <td
+                            style="background-color: #F9FAFB; padding: 40px 30px; text-align: center; border-top: 1px solid #E5E7EB;">
+                            
+                            <p style="font-size: 13px; color: #9CA3AF; margin: 0;">
+                                İletişim için: <a href="mailto:hey@letsraffle.co"
+                                    style="color: #6B7280; text-decoration: underline;">hey@letsraffle.co</a>
+                            </p>
+                        </td>
+                    </tr>
+                </table>
+
+                <!-- Copyright -->
+                <p style="text-align: center; margin-top: 20px; font-size: 12px; color: #FECACA; opacity: 0.8;">
+                    © 2025 LetsRaffle. All rights reserved.
+                </p>
+            </td>
+        </tr>
+    </table>
+</body>
+
+</html>


### PR DESCRIPTION
## Add Password Reset Feature

### Changes
- **Auth Endpoints**: Added `POST /auth/forgot-password` and `POST /auth/reset-password` endpoints
- **Email Service**: Implemented [send_password_reset_email](cci:1://file:///Users/selametsamli/Desktop/santa_draw_all_in_one/santas_draw/app/services/email_service.py:221:4-269:24) method with TR/EN template support
- **Celery Task**: Created [send_password_reset_email_task](cci:1://file:///Users/selametsamli/Desktop/santa_draw_all_in_one/santas_draw/app/tasks/email_tasks.py:13:0-46:53) for asynchronous email sending
- **Email Templates**: Added `reset-password-template-tr.html` and [reset-password-template-en.html](cci:7://file:///Users/selametsamli/Desktop/santa_draw_all_in_one/santas_draw/app/templates/reset-password-template-en.html:0:0-0:0)
- **Schemas**: Added [ForgotPasswordRequest](cci:2://file:///Users/selametsamli/Desktop/santa_draw_all_in_one/santas_draw/app/schemas/user.py:43:0-46:24) and [ResetPasswordRequest](cci:2://file:///Users/selametsamli/Desktop/santa_draw_all_in_one/santas_draw/app/schemas/user.py:49:0-52:21) with language support
- **Config**: Added `frontend_url` setting for reset link generation

### Technical Details
- Reset tokens expire in 1 hour
- Language detection is case-insensitive (supports both [tr](cci:1://file:///Users/selametsamli/Desktop/santa_draw_all_in_one/santas_draw_frontend/src/views/HomeView.vue:172:0-174:1)/`TR` and [en](cci:1://file:///Users/selametsamli/Desktop/santa_draw_all_in_one/santas_draw_frontend/src/router/index.ts:6:8-6:55)/`EN`)
- Email sending is non-blocking via Celery
- Updated [.env.example](cci:7://file:///Users/selametsamli/Desktop/santa_draw_all_in_one/santas_draw/.env.example:0:0-0:0) with AWS SES and frontend URL configuration